### PR TITLE
Platform.tmp crashing on NRT guide

### DIFF
--- a/HelpSource/Guides/Non-Realtime-Synthesis.schelp
+++ b/HelpSource/Guides/Non-Realtime-Synthesis.schelp
@@ -174,7 +174,7 @@ teletype::recordNRT:: allows you optionally to specify the path to the binary OS
 If you do not give a path, teletype::recordNRT:: will generate one for you in the system's temporary file location. These files are not automatically deleted after rendering. Some systems may automatically clean up old temporary files after some time. Otherwise, you can take it into your own hands:
 
 code::
-var oscPath = Platform.tmp +/+ "mytempscore";
+var oscPath = Platform.defaultTempDir +/+ "mytempscore";
 
 x = Score([ ... ]);
 


### PR DESCRIPTION

<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

`Platform.tmp` doesn't seems to exist anymore, so it should be replaced by `Platform.defaultTempDir`. It seems to be present only at `Non-Realtime Synthesis (NRT)` Guide.


## Types of changes

<!-- Delete lines that don't apply -->

- Documentation

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested
- [x] All tests are passing
- [x] Updated documentation
- [ ] This PR is ready for review
